### PR TITLE
Add disposal state assertions for async defers

### DIFF
--- a/DotNetDefer.Tests/DeferAsyncTests.cs
+++ b/DotNetDefer.Tests/DeferAsyncTests.cs
@@ -85,6 +85,8 @@ public class DeferAsyncTests
         });
         await defer.DisposeAsync();
         await defer.DisposeAsync();
+        Assert.True(defer.IsDisposed);
+        Assert.Null(defer.Error);
         Assert.Equal(1, x);
     }
 


### PR DESCRIPTION
## Summary
- ensure DisposeAsync twice leaves defer disposed and error-free

## Testing
- `~/.dotnet/dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6891e52cef08833399abb21250fefe0e